### PR TITLE
feat: Bumps subql node version to custom v4.3.0

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -10,7 +10,7 @@ COPY . ./
 RUN npm run codegen && npm run build
 
 
-FROM onfinality/subql-node:v3.10.1 as runner
+FROM availj/subquery-node-avail:v4.3.0 as runner
 WORKDIR /app
 COPY --from=builder /build-stage/dist /app/dist
 COPY --from=builder /build-stage/project.yaml /app


### PR DESCRIPTION
## Description
- [x] Bumps subql node version to custom v4.3.0

## Motivation and Context
Indexer can't process more than 65K events in a block due to subql PolkadotJS hardcoded MAX_LENGTH constraint.
A custom base image was generated from the [following patch](https://github.com/availproject/subql/commit/e1dd788e7a57823ded01f4ff2e0ed611276fbd0f).

We must change the base image in avail-indexer Dockerfile.release to support new MAX_LENGTH values, therefore event limit processing.

## How Has This Been Tested?
- Already in production for Turing

## Screenshots (if appropriate)
