### PR TITLE
fix: Removes unused types.json to prevent build errors

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -13,4 +13,3 @@ WORKDIR /app
 COPY --from=builder /build-stage/dist /app/dist
 COPY --from=builder /build-stage/project.yaml /app
 COPY --from=builder /build-stage/schema.graphql /app
-COPY --from=builder /build-stage/types.json /app


### PR DESCRIPTION
## Description
- [x] Removes missing sunset types.json to prevent build errors

## Motivation and Context
Docker builds are failing due to missing `types.json`, which was moved to `src/chaintypes.ts`

## How Has This Been Tested?
Locally built docker image.

## Screenshots (if appropriate)
