### PR TITLE
feat: expose txHash on TransferEntity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -102,6 +102,7 @@ type TransferEntity @entity {
   currency: String!
   amount: String!
   amountRounded: Float! @index
+  txHash: String! @index 
 }
 
 type AccountEntity @entity {

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -91,8 +91,7 @@ export async function handleBlock(block: CorrectSubstrateBlock): Promise<void> {
               blockHash,
               block.timestamp,
               relatedExtrinsicIndex !== -1 ? `${blockNumber}-${relatedExtrinsicIndex}` : "",
-              idx
-            ))
+              idx, relatedExtrinsicIndex !== -1 ? block.block.extrinsics[relatedExtrinsicIndex].hash.toString() : ""))
             const [fromRaw, toRaw, _] = evt.event.data
             const from = fromRaw.toString()
             const to = toRaw.toString()

--- a/src/utils/balances.ts
+++ b/src/utils/balances.ts
@@ -82,20 +82,30 @@ export const updateAccounts = async (addresses: string[], timestamp: Date) => {
     }
 }
 
-export const transferHandler = (event: EventRecord, blockId: string, blockHash: string, timestamp: Date, extrinsicIndex: string, eventIndex: number) => {
+export const transferHandler = (
+    event: EventRecord,
+    blockId: string,
+    blockHash: string,
+    timestamp: Date,
+    extrinsicId: string,
+    eventIndex: number,
+    txHash: string,
+) => {
     const [from, to, amount] = event.event.data
-    const formattedAmount = !(typeof amount === "string") ? (amount as Balance).toBigInt().toString() : amount
+    const formattedAmount = typeof amount === "string" ? amount : (amount as Balance).toBigInt().toString()
+
     const record = new TransferEntity(
         `${blockId}-${eventIndex}`,
         blockId,
         blockHash,
-        extrinsicIndex,
+        extrinsicId,
         timestamp,
         from.toString(),
         to.toString(),
         "AVL",
         formattedAmount,
-        roundPrice(formattedAmount)
+        roundPrice(formattedAmount),
+        txHash,
     )
     return record
 }


### PR DESCRIPTION
### What
Adds `txHash` to TransferEntity so consumers can fetch the transaction hash in the same call as transfer details.

### Why
Liquidity dashboards currently need an extra query per transfer to resolve the hash. This saves one round-trip and simplifies client code.

### How
* **schema.graphql** – `txHash: String! @index`
* **balances.ts** – grab `event.extrinsic.hash` and store in TransferEntity
* **mappingHandlers.ts** – pass `txHash` (7th arg) into `transferHandler`

Verified locally:
- `yarn codegen && yarn build` succeed
- Docker stack syncs; GraphQL returns `txHash` field
