### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           username: ${{ secrets.DO_USER_EMAIL }}
           password: ${{ secrets.DO_USER_TOKEN }}
       - name: Build and push images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .


### PR DESCRIPTION
Updated docker/build-push-action from v5 to v6.
The latest version (v6.18.0) adds support for Docker Build Cloud in build summary.
Proof: [docker/build-push-action v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)